### PR TITLE
Implement KMP and Android standalone plugins

### DIFF
--- a/unified-prototype/build.gradle.kts
+++ b/unified-prototype/build.gradle.kts
@@ -1,0 +1,3 @@
+plugins {
+    id("org.gradle.experimental.android-library") apply false
+}

--- a/unified-prototype/settings.gradle.kts
+++ b/unified-prototype/settings.gradle.kts
@@ -7,6 +7,13 @@ pluginManagement {
     includeBuild("unified-plugin")
 }
 
+dependencyResolutionManagement {
+    repositories {
+        mavenCentral()
+        google()
+    }
+}
+
 rootProject.name = "unified-prototype"
 
 include("testbed-android")

--- a/unified-prototype/testbed-android-groovy/build.gradle
+++ b/unified-prototype/testbed-android-groovy/build.gradle
@@ -3,7 +3,19 @@ plugins {
 }
 
 androidLibrary {
+    jdkVersion = 17
+    compileSdk = 34
+    namespace = "org.gradle.experimental.android.library.kotlin"
+
     dependencies {
-        api("org:foo:1.0")
+        api("com.google.guava:guava:32.1.3-jre")
+    }
+
+    targets {
+        create("debug") {
+            dependencies {
+                implementation("org.apache.commons:commons-lang3:3.14.0")
+            }
+        }
     }
 }

--- a/unified-prototype/testbed-android/build.gradle.kts
+++ b/unified-prototype/testbed-android/build.gradle.kts
@@ -3,7 +3,19 @@ plugins {
 }
 
 androidLibrary {
+    jdkVersion = 17
+    compileSdk = 34
+    namespace = "org.gradle.experimental.android.library.kotlin"
+
     dependencies {
-        api("org:foo:1.0")
+        api("com.google.guava:guava:32.1.3-jre")
+    }
+
+    targets {
+        create("debug") {
+            dependencies {
+                implementation("org.apache.commons:commons-lang3:3.14.0")
+            }
+        }
     }
 }

--- a/unified-prototype/testbed-kmp-groovy/build.gradle
+++ b/unified-prototype/testbed-kmp-groovy/build.gradle
@@ -2,8 +2,28 @@ plugins {
     id("org.gradle.experimental.kmp-library")
 }
 
+import org.gradle.api.experimental.kmp.KmpJsTarget.JsEnvironment
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
 kmpLibrary {
     dependencies {
-        api("org:foo:1.0")
+        api("io.ktor:ktor-client-core:2.3.7")
+    }
+
+    targets {
+        jvm {
+            jvmTarget = JvmTarget.JVM_14
+
+            dependencies {
+                api("org.apache.commons:commons-lang3:3.14.0")
+            }
+        }
+        js {
+            environment = JsEnvironment.NODE
+
+            dependencies {
+                implementation("com.squareup.sqldelight:runtime:1.5.5")
+            }
+        }
     }
 }

--- a/unified-prototype/testbed-kmp/build.gradle.kts
+++ b/unified-prototype/testbed-kmp/build.gradle.kts
@@ -1,9 +1,29 @@
+import org.gradle.api.experimental.kmp.KmpJsTarget.JsEnvironment
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
 plugins {
     id("org.gradle.experimental.kmp-library")
 }
 
 kmpLibrary {
     dependencies {
-        api("org:foo:1.0")
+        api("io.ktor:ktor-client-core:2.3.7")
+    }
+
+    targets {
+        jvm {
+            jvmTarget = JvmTarget.JVM_14
+
+            dependencies {
+                api("org.apache.commons:commons-lang3:3.14.0")
+            }
+        }
+        js {
+            environment = JsEnvironment.NODE
+
+            dependencies {
+                implementation("com.squareup.sqldelight:runtime:1.5.5")
+            }
+        }
     }
 }

--- a/unified-prototype/unified-plugin/gradle/libs.versions.toml
+++ b/unified-prototype/unified-plugin/gradle/libs.versions.toml
@@ -1,0 +1,14 @@
+[versions]
+# Find latest version at: https://kotlinlang.org/docs/releases.html#release-details
+kotlin = "1.9.22"
+
+# Find latest version at: https://developer.android.com/reference/tools/gradle-api
+android = "8.2.2"
+
+[libraries]
+# Kotlin dependencies
+kotlin-multiplatform = { module = "org.jetbrains.kotlin.multiplatform:org.jetbrains.kotlin.multiplatform.gradle.plugin", version.ref = "kotlin" }
+
+# Android dependencies
+android-agp-application = { module = "com.android.application:com.android.application.gradle.plugin", version.ref = "android" }
+android-kotlin-android = { module = "org.jetbrains.kotlin.android:org.jetbrains.kotlin.android.gradle.plugin", version.ref = "kotlin" }

--- a/unified-prototype/unified-plugin/plugin-android/build.gradle.kts
+++ b/unified-prototype/unified-plugin/plugin-android/build.gradle.kts
@@ -6,6 +6,8 @@ description = "Implements the declarative Android DSL prototype"
 
 dependencies {
     implementation(project(":plugin-common"))
+    implementation(libs.android.agp.application)
+    implementation(libs.android.kotlin.android)
 }
 
 gradlePlugin {
@@ -14,5 +16,14 @@ gradlePlugin {
             id = "org.gradle.experimental.android-library"
             implementationClass = "org.gradle.api.experimental.android.StandaloneAndroidLibraryPlugin"
         }
+    }
+}
+
+// Compile against Java 17 since Android requires Java 17 at minimum
+java {
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
     }
 }

--- a/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/AndroidLibrary.java
+++ b/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/AndroidLibrary.java
@@ -1,7 +1,12 @@
 package org.gradle.api.experimental.android;
 
+import com.android.build.api.dsl.BaseFlavor;
+import com.android.build.api.dsl.CommonExtension;
 import org.gradle.api.Action;
+import org.gradle.api.NamedDomainObjectContainer;
 import org.gradle.api.experimental.common.LibraryDependencies;
+import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Nested;
 
 /**
@@ -9,11 +14,45 @@ import org.gradle.api.tasks.Nested;
  */
 public interface AndroidLibrary {
 
+    /**
+     * @see CommonExtension#getNamespace()
+     */
+    @Input
+    Property<String> getNamespace();
+
+    /**
+     * @see CommonExtension#getCompileSdk()
+     */
+    @Input
+    Property<Integer> getCompileSdk();
+
+    /**
+     * @see BaseFlavor#getMinSdk()
+     */
+    @Input
+    Property<Integer> getMinSdk();
+
+    /**
+     * JDK version to use for compilation.
+     */
+    @Input
+    Property<Integer> getJdkVersion();
+
+    /**
+     * Common dependencies for all targets.
+     */
     @Nested
     LibraryDependencies getDependencies();
 
     default void dependencies(Action<? super LibraryDependencies> action) {
         action.execute(getDependencies());
+    }
+
+    @Nested
+    NamedDomainObjectContainer<AndroidTarget> getTargets();
+
+    default void targets(Action<? super NamedDomainObjectContainer<AndroidTarget>> action) {
+        action.execute(getTargets());
     }
 
 }

--- a/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/AndroidTarget.java
+++ b/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/AndroidTarget.java
@@ -1,21 +1,24 @@
-package org.gradle.api.experimental.kmp;
+package org.gradle.api.experimental.android;
 
+import com.android.build.api.dsl.BaseFlavor;
 import org.gradle.api.Action;
+import org.gradle.api.Named;
 import org.gradle.api.experimental.common.LibraryDependencies;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Nested;
 
-import javax.inject.Inject;
+public interface AndroidTarget extends Named {
 
-/**
- * The public DSL interface for a declarative KMP library.
- */
-public interface KmpLibrary {
-
+    /**
+     * @see BaseFlavor#getMinSdk()
+     */
     @Input
-    Property<String> getLanguageVersion();
+    Property<Integer> getMinSdk();
 
+    /**
+     * Dependencies for this target.
+     */
     @Nested
     LibraryDependencies getDependencies();
 
@@ -23,9 +26,4 @@ public interface KmpLibrary {
         action.execute(getDependencies());
     }
 
-    KmpTargetContainer getTargets();
-
-    default void targets(Action<? super KmpTargetContainer> action) {
-        action.execute(getTargets());
-    }
 }

--- a/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/StandaloneAndroidLibraryPlugin.java
+++ b/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/StandaloneAndroidLibraryPlugin.java
@@ -1,7 +1,13 @@
 package org.gradle.api.experimental.android;
 
-import org.gradle.api.Plugin;
-import org.gradle.api.Project;
+import com.android.build.api.dsl.LibraryExtension;
+import com.android.build.api.variant.AndroidComponentsExtension;
+import org.gradle.api.*;
+import org.gradle.api.provider.Property;
+import org.jetbrains.kotlin.gradle.dsl.KotlinAndroidProjectExtension;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Creates a declarative {@link AndroidLibrary} DSL model, applies the official Android plugin,
@@ -10,9 +16,105 @@ import org.gradle.api.Project;
 public class StandaloneAndroidLibraryPlugin implements Plugin<Project> {
     @Override
     public void apply(Project project) {
-        project.getExtensions().create("androidLibrary", AndroidLibrary.class);
-        System.out.println("Applied Android!");
+        AndroidLibrary dslModel = project.getExtensions().create("androidLibrary", AndroidLibrary.class);
 
-        // TODO: Actually do something here
+        // Register an afterEvaluate listener before we apply the Android plugin to ensure we can
+        // run actions before Android does.
+        project.afterEvaluate(p -> linkDslModelToPlugin(p, dslModel));
+
+        // Apply the official Android plugin.
+        project.getPlugins().apply("com.android.library");
+        project.getPlugins().apply("org.jetbrains.kotlin.android");
+
+        linkDslModelToPluginLazy(project, dslModel);
     }
+
+    /**
+     * Performs linking actions that must occur within an afterEvaluate block.
+     */
+    private void linkDslModelToPlugin(Project project, AndroidLibrary dslModel) {
+        LibraryExtension android = project.getExtensions().getByType(LibraryExtension.class);
+        KotlinAndroidProjectExtension kotlin = project.getExtensions().getByType(KotlinAndroidProjectExtension.class);
+
+        // Link common properties
+        ifPresent(dslModel.getNamespace(), android::setNamespace);
+        ifPresent(dslModel.getCompileSdk(), android::setCompileSdk);
+        android.defaultConfig(defaultConfig -> {
+            ifPresent(dslModel.getMinSdk(), defaultConfig::setMinSdk);
+            return null;
+        });
+        ifPresent(dslModel.getJdkVersion(), jdkVersion -> {
+            kotlin.jvmToolchain(jdkVersion);
+            android.getCompileOptions().setSourceCompatibility(JavaVersion.toVersion(jdkVersion));
+            android.getCompileOptions().setTargetCompatibility(JavaVersion.toVersion(jdkVersion));
+        });
+    }
+
+    /**
+     * Performs linking actions that do not need to occur within an afterEvaluate block.
+     */
+    private void linkDslModelToPluginLazy(Project project, AndroidLibrary dslModel) {
+        AndroidComponentsExtension<?, ?, ?> androidComponents = project.getExtensions().getByType(AndroidComponentsExtension.class);
+
+        // Link common dependencies
+        project.getConfigurations().getByName("implementation").getDependencies()
+            .addAllLater(dslModel.getDependencies().getImplementation().getDependencies());
+        project.getConfigurations().getByName("api").getDependencies()
+            .addAllLater(dslModel.getDependencies().getApi().getDependencies());
+        project.getConfigurations().getByName("compileOnly").getDependencies()
+            .addAllLater(dslModel.getDependencies().getCompileOnly().getDependencies());
+        project.getConfigurations().getByName("runtimeOnly").getDependencies()
+            .addAllLater(dslModel.getDependencies().getRuntimeOnly().getDependencies());
+
+        // Link target-specific properties
+        androidComponents.beforeVariants(androidComponents.selector().all(), variant -> {
+            AndroidTarget target = dslModel.getTargets().findByName(variant.getName());
+            if (target == null) {
+                // The user did not add any target-specific configuration.
+                return;
+            }
+
+            ifPresent(target.getMinSdk(), variant::setMinSdk);
+        });
+
+        // Link target-specific dependencies
+        List<String> variantNames = new ArrayList<>();
+        androidComponents.onVariants(androidComponents.selector().all(), variant -> {
+            String name = variant.getName();
+            variantNames.add(name);
+
+
+            AndroidTarget target = dslModel.getTargets().findByName(name);
+            if (target == null) {
+                // The user did not add any target-specific configuration.
+                return;
+            }
+
+            project.getConfigurations().getByName(name + "Implementation").getDependencies()
+                .addAllLater(target.getDependencies().getImplementation().getDependencies());
+            project.getConfigurations().getByName(name + "Api").getDependencies()
+                .addAllLater(target.getDependencies().getApi().getDependencies());
+            project.getConfigurations().getByName(name + "CompileOnly").getDependencies()
+                .addAllLater(target.getDependencies().getCompileOnly().getDependencies());
+            project.getConfigurations().getByName(name + "RuntimeOnly").getDependencies()
+                .addAllLater(target.getDependencies().getRuntimeOnly().getDependencies());
+        });
+
+        // This will run after all onVariants calls.
+        project.afterEvaluate(p -> dslModel.getTargets().all(target -> {
+            if (!variantNames.contains(target.getName())) {
+                throw new InvalidUserDataException(String.format(
+                    "Configured target '%s' but an Android variant with the same name does not exist.",
+                    target.getName()
+                ));
+            }
+        }));
+    }
+
+    private static <T> void ifPresent(Property<T> property, Action<T> action) {
+        if (property.isPresent()) {
+            action.execute(property.get());
+        }
+    }
+
 }

--- a/unified-prototype/unified-plugin/plugin-common/build.gradle.kts
+++ b/unified-prototype/unified-plugin/plugin-common/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("java-library")
+    kotlin("jvm") version libs.versions.kotlin
 }
 
 dependencies {

--- a/unified-prototype/unified-plugin/plugin-common/src/main/java/org/gradle/api/experimental/common/LibraryDependencies.java
+++ b/unified-prototype/unified-plugin/plugin-common/src/main/java/org/gradle/api/experimental/common/LibraryDependencies.java
@@ -14,6 +14,9 @@ public interface LibraryDependencies extends PlatformDependencyModifiers, TestFi
     DependencyCollector getImplementation();
     DependencyCollector getRuntimeOnly();
     DependencyCollector getCompileOnly();
-    DependencyCollector getCompileOnlyApi();
+
+    // CompileOnlyApi is not included here, since both Android and KMP do not support it.
+    // Does that mean we should also reconsider if we should support it? Or, should we
+    // talk to Android and KMP about adding support
 
 }

--- a/unified-prototype/unified-plugin/plugin-kmp/build.gradle.kts
+++ b/unified-prototype/unified-plugin/plugin-kmp/build.gradle.kts
@@ -6,6 +6,7 @@ description = "Implements the declarative KMP DSL prototype"
 
 dependencies {
     implementation(project(":plugin-common"))
+    implementation(libs.kotlin.multiplatform)
 }
 
 gradlePlugin {

--- a/unified-prototype/unified-plugin/plugin-kmp/src/main/java/org/gradle/api/experimental/kmp/AbstractKmpLibrary.java
+++ b/unified-prototype/unified-plugin/plugin-kmp/src/main/java/org/gradle/api/experimental/kmp/AbstractKmpLibrary.java
@@ -1,0 +1,35 @@
+package org.gradle.api.experimental.kmp;
+
+import org.gradle.api.internal.CollectionCallbackActionDecorator;
+import org.gradle.internal.instantiation.InstantiatorFactory;
+import org.gradle.internal.reflect.Instantiator;
+import org.gradle.internal.service.ServiceRegistry;
+
+import javax.inject.Inject;
+
+/**
+ * This ideally should not exist and {@link KmpLibrary} should be expressed as only an interface,
+ * however the KMP targets container needs some special handling for now.
+ */
+public abstract class AbstractKmpLibrary implements KmpLibrary {
+
+    private final KmpTargetContainer targets;
+
+    @Inject
+    public AbstractKmpLibrary(
+        Instantiator instantiator,
+        InstantiatorFactory instantiatorFactory,
+        ServiceRegistry services,
+        CollectionCallbackActionDecorator decorator
+    ) {
+        Instantiator elementInstantiator = instantiatorFactory.decorateLenient(services);
+        targets = instantiator.newInstance(KmpTargetContainer.class, instantiator, elementInstantiator, decorator);
+        targets.registerBinding(KmpJvmTarget.class, KmpJvmTarget.class);
+        targets.registerBinding(KmpJsTarget.class, KmpJsTarget.class);
+    }
+
+    @Override
+    public KmpTargetContainer getTargets() {
+        return targets;
+    }
+}

--- a/unified-prototype/unified-plugin/plugin-kmp/src/main/java/org/gradle/api/experimental/kmp/KmpJsTarget.java
+++ b/unified-prototype/unified-plugin/plugin-kmp/src/main/java/org/gradle/api/experimental/kmp/KmpJsTarget.java
@@ -1,0 +1,13 @@
+package org.gradle.api.experimental.kmp;
+
+import org.gradle.api.provider.Property;
+
+public interface KmpJsTarget extends KmpTarget {
+
+    Property<JsEnvironment> getEnvironment();
+
+    enum JsEnvironment {
+        NODE, BROWSER
+    }
+
+}

--- a/unified-prototype/unified-plugin/plugin-kmp/src/main/java/org/gradle/api/experimental/kmp/KmpJvmTarget.java
+++ b/unified-prototype/unified-plugin/plugin-kmp/src/main/java/org/gradle/api/experimental/kmp/KmpJvmTarget.java
@@ -1,0 +1,10 @@
+package org.gradle.api.experimental.kmp;
+
+import org.gradle.api.provider.Property;
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget;
+
+public interface KmpJvmTarget extends KmpTarget {
+
+    Property<JvmTarget> getJvmTarget();
+
+}

--- a/unified-prototype/unified-plugin/plugin-kmp/src/main/java/org/gradle/api/experimental/kmp/KmpTarget.java
+++ b/unified-prototype/unified-plugin/plugin-kmp/src/main/java/org/gradle/api/experimental/kmp/KmpTarget.java
@@ -1,0 +1,17 @@
+package org.gradle.api.experimental.kmp;
+
+import org.gradle.api.Action;
+import org.gradle.api.Named;
+import org.gradle.api.experimental.common.LibraryDependencies;
+import org.gradle.api.tasks.Nested;
+
+public interface KmpTarget extends Named {
+
+    @Nested
+    LibraryDependencies getDependencies();
+
+    default void dependencies(Action<? super LibraryDependencies> action) {
+        action.execute(getDependencies());
+    }
+
+}

--- a/unified-prototype/unified-plugin/plugin-kmp/src/main/java/org/gradle/api/experimental/kmp/KmpTargetContainer.java
+++ b/unified-prototype/unified-plugin/plugin-kmp/src/main/java/org/gradle/api/experimental/kmp/KmpTargetContainer.java
@@ -1,0 +1,46 @@
+package org.gradle.api.experimental.kmp;
+
+import org.gradle.api.Action;
+import org.gradle.api.internal.CollectionCallbackActionDecorator;
+import org.gradle.api.internal.DefaultPolymorphicDomainObjectContainer;
+import org.gradle.internal.reflect.Instantiator;
+
+public class KmpTargetContainer extends DefaultPolymorphicDomainObjectContainer<KmpTarget> {
+
+    public KmpTargetContainer(Instantiator instantiator, Instantiator elementInstantiator, CollectionCallbackActionDecorator callbackDecorator) {
+        super(KmpTarget.class, instantiator, elementInstantiator, callbackDecorator);
+    }
+
+    public void jvm() {
+        create("jvm", KmpJvmTarget.class);
+    }
+
+    public void jvm(String name) {
+        create(name, KmpJvmTarget.class);
+    }
+
+    public void jvm(Action<? super KmpJvmTarget> action) {
+        create("jvm", KmpJvmTarget.class, action);
+    }
+
+    public void jvm(String name, Action<? super KmpJvmTarget> action) {
+        create(name, KmpJvmTarget.class, action);
+    }
+
+    public void js() {
+        create("js", KmpJsTarget.class);
+    }
+
+    public void js(String name) {
+        create(name, KmpJsTarget.class);
+    }
+
+    public void js(Action<? super KmpJsTarget> action) {
+        create("js", KmpJsTarget.class, action);
+    }
+
+    public void js(String name, Action<? super KmpJsTarget> action) {
+        create(name, KmpJsTarget.class, action);
+    }
+
+}

--- a/unified-prototype/unified-plugin/plugin-kmp/src/main/java/org/gradle/api/experimental/kmp/StandaloneKmpLibraryPlugin.java
+++ b/unified-prototype/unified-plugin/plugin-kmp/src/main/java/org/gradle/api/experimental/kmp/StandaloneKmpLibraryPlugin.java
@@ -1,7 +1,12 @@
 package org.gradle.api.experimental.kmp;
 
+import org.gradle.api.Action;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
+import org.gradle.api.experimental.common.LibraryDependencies;
+import org.gradle.api.provider.Property;
+import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension;
+import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSet;
 
 /**
  * Creates a declarative {@link KmpLibrary} DSL model, applies the official KMP plugin,
@@ -10,9 +15,91 @@ import org.gradle.api.Project;
 public class StandaloneKmpLibraryPlugin implements Plugin<Project> {
     @Override
     public void apply(Project project) {
-        project.getExtensions().create("kmpLibrary", KmpLibrary.class);
-        System.out.println("Applied KMP!");
+         KmpLibrary dslModel =project.getExtensions().create("kmpLibrary", AbstractKmpLibrary.class);
 
-        // TODO: Actually do something here
+        // Register an afterEvaluate listener before we apply the Android plugin to ensure we can
+        // run actions before Android does.
+        project.afterEvaluate(p -> linkDslModelToPlugin(p, dslModel));
+
+        // Apply the official KMP plugin.
+        project.getPlugins().apply("org.jetbrains.kotlin.multiplatform");
+
+        linkDslModelToPluginLazy(project, dslModel);
+    }
+
+    /**
+     * Performs linking actions that must occur within an afterEvaluate block.
+     */
+    private void linkDslModelToPlugin(Project project, KmpLibrary dslModel) {
+        KotlinMultiplatformExtension kotlin = project.getExtensions().getByType(KotlinMultiplatformExtension.class);
+
+        // Link common properties
+        kotlin.getSourceSets().configureEach(sourceSet -> {
+            sourceSet.languageSettings(languageSettings -> {
+                ifPresent(dslModel.getLanguageVersion(), languageSettings::setLanguageVersion);
+                ifPresent(dslModel.getLanguageVersion(), languageSettings::setApiVersion);
+            });
+        });
+        dslModel.getTargets().withType(KmpJsTarget.class).all(target -> {
+            kotlin.js(target.getName(), kotlinTarget -> {
+                if (target.getEnvironment().get() == KmpJsTarget.JsEnvironment.NODE) {
+                    kotlinTarget.nodejs();
+                } else {
+                    kotlinTarget.browser();
+                }
+            });
+        });
+    }
+
+    /**
+     * Performs linking actions that do not need to occur within an afterEvaluate block.
+     */
+    private void linkDslModelToPluginLazy(Project project, KmpLibrary dslModel) {
+        KotlinMultiplatformExtension kotlin = project.getExtensions().getByType(KotlinMultiplatformExtension.class);
+
+        // Link common dependencies
+        linkSourceSetToDependencies(project, kotlin.getSourceSets().getByName("commonMain"), dslModel.getDependencies());
+
+        // Link JVM targets
+        dslModel.getTargets().withType(KmpJvmTarget.class).all(target -> {
+            kotlin.jvm(target.getName(), kotlinTarget -> {
+                linkSourceSetToDependencies(
+                    project,
+                    kotlinTarget.getCompilations().getByName("main").getDefaultSourceSet(),
+                    target.getDependencies()
+                );
+                kotlinTarget.getCompilations().configureEach(compilation -> {
+                    compilation.getCompilerOptions().getOptions().getJvmTarget().set(target.getJvmTarget());
+                });
+            });
+        });
+
+        // Link JS targets
+        dslModel.getTargets().withType(KmpJsTarget.class).all(target -> {
+            kotlin.js(target.getName(), kotlinTarget -> {
+                linkSourceSetToDependencies(
+                    project,
+                    kotlinTarget.getCompilations().getByName("main").getDefaultSourceSet(),
+                    target.getDependencies()
+                );
+            });
+        });
+    }
+
+    private static void linkSourceSetToDependencies(Project project, KotlinSourceSet sourceSet, LibraryDependencies dependencyCollector) {
+        project.getConfigurations().getByName(sourceSet.getImplementationConfigurationName())
+            .getDependencies().addAllLater(dependencyCollector.getImplementation().getDependencies());
+        project.getConfigurations().getByName(sourceSet.getApiConfigurationName())
+            .getDependencies().addAllLater(dependencyCollector.getApi().getDependencies());
+        project.getConfigurations().getByName(sourceSet.getCompileOnlyConfigurationName())
+            .getDependencies().addAllLater(dependencyCollector.getCompileOnly().getDependencies());
+        project.getConfigurations().getByName(sourceSet.getRuntimeOnlyConfigurationName())
+            .getDependencies().addAllLater(dependencyCollector.getRuntimeOnly().getDependencies());
+    }
+
+    private static <T> void ifPresent(Property<T> property, Action<T> action) {
+        if (property.isPresent()) {
+            action.execute(property.get());
+        }
     }
 }


### PR DESCRIPTION
Implements minimal KMP and Android plugins.

Android targets are hard-coded
KMP targets are dynamic

Can declare common common dependencies and target-specific dependencies on both Android and KGP Can also declare common and taget-specific properties for both Android and KGP