### PR TITLE
Implement multi-target Jvm library plugin

### DIFF
--- a/unified-prototype/testbed-jvm-groovy/build.gradle
+++ b/unified-prototype/testbed-jvm-groovy/build.gradle
@@ -4,6 +4,20 @@ plugins {
 
 jvmLibrary {
     dependencies {
-        api("org:foo:1.0")
+        implementation("org.apache.commons:commons-lang3:3.14.0")
+    }
+    targets {
+        java(11) {
+            dependencies {
+                // Requires java 11
+                implementation("org.hibernate.orm:hibernate-core:6.4.2.Final")
+            }
+        }
+        java(17) {
+            dependencies {
+                // Requires java 17
+                implementation("org.springframework.boot:spring-boot:3.2.2")
+            }
+        }
     }
 }

--- a/unified-prototype/testbed-jvm/build.gradle.kts
+++ b/unified-prototype/testbed-jvm/build.gradle.kts
@@ -4,6 +4,40 @@ plugins {
 
 jvmLibrary {
     dependencies {
-        api("org:foo:1.0")
+        implementation("org.apache.commons:commons-lang3:3.14.0")
+    }
+    targets {
+        java(11) {
+            dependencies {
+                // Requires java 11
+                implementation("org.hibernate.orm:hibernate-core:6.4.2.Final")
+            }
+        }
+        java(17) {
+            dependencies {
+                // Requires java 17
+                implementation("org.springframework.boot:spring-boot:3.2.2")
+            }
+        }
+    }
+}
+
+// These tasks are to showcase that we can actually execute
+// the above libraries. If we had applications or implemented testing,
+// we would not need these tasks.
+
+tasks.register<JavaExec>("executeJava11") {
+    mainClass = "com.example.Entrypoint"
+    classpath = (configurations["java11RuntimeClasspath"] + sourceSets["java11"].output)
+    javaLauncher = javaToolchains.launcherFor {
+        languageVersion.set(JavaLanguageVersion.of(11))
+    }
+}
+
+tasks.register<JavaExec>("executeJava17") {
+    mainClass = "com.example.Entrypoint"
+    classpath = (configurations["java17RuntimeClasspath"] + sourceSets["java17"].output)
+    javaLauncher = javaToolchains.launcherFor {
+        languageVersion.set(JavaLanguageVersion.of(17))
     }
 }

--- a/unified-prototype/testbed-jvm/src/common/java/com/example/Common.java
+++ b/unified-prototype/testbed-jvm/src/common/java/com/example/Common.java
@@ -1,0 +1,11 @@
+package com.example;
+
+import org.apache.commons.lang3.StringUtils;
+
+public class Common {
+    public String getValue() {
+        String value = StringUtils.valueOf(new char[] { '4', '2' });
+        String version = "The runtime java version is " + System.getProperty("java.version");
+        return value + ". " + version;
+    }
+}

--- a/unified-prototype/testbed-jvm/src/common/java/com/example/Entrypoint.java
+++ b/unified-prototype/testbed-jvm/src/common/java/com/example/Entrypoint.java
@@ -1,0 +1,14 @@
+package com.example;
+
+import java.util.ServiceLoader;
+
+public class Entrypoint {
+
+    public static void main(String[] args) {
+        new Entrypoint().run();
+    }
+
+    public void run() {
+        ServiceLoader.load(Interface.class).forEach(impl -> System.out.println(impl.getValue()));
+    }
+}

--- a/unified-prototype/testbed-jvm/src/common/java/com/example/Interface.java
+++ b/unified-prototype/testbed-jvm/src/common/java/com/example/Interface.java
@@ -1,0 +1,6 @@
+package com.example;
+
+public interface Interface {
+
+    String getValue();
+}

--- a/unified-prototype/testbed-jvm/src/java11/java/com/example/Eleven.java
+++ b/unified-prototype/testbed-jvm/src/java11/java/com/example/Eleven.java
@@ -1,0 +1,11 @@
+package com.example;
+
+public class Eleven implements Interface {
+
+    @Override
+    public String getValue() {
+        var result = "Java 11. The value is " + new Common().getValue() + ". Hibernate version is " + org.hibernate.Version.getVersionString();
+        return result;
+    }
+
+}

--- a/unified-prototype/testbed-jvm/src/java11/resources/META-INF/services/com.example.Interface
+++ b/unified-prototype/testbed-jvm/src/java11/resources/META-INF/services/com.example.Interface
@@ -1,0 +1,1 @@
+com.example.Eleven

--- a/unified-prototype/testbed-jvm/src/java17/java/com/example/Seventeen.java
+++ b/unified-prototype/testbed-jvm/src/java17/java/com/example/Seventeen.java
@@ -1,0 +1,12 @@
+package com.example;
+
+import org.springframework.core.SpringVersion;
+
+public record Seventeen() implements Interface {
+
+    @Override
+    public String getValue() {
+        return "Java 17. The value is " + new Common().getValue() + ". The spring version is " + SpringVersion.getVersion();
+    }
+
+}

--- a/unified-prototype/testbed-jvm/src/java17/resources/META-INF/services/com.example.Interface
+++ b/unified-prototype/testbed-jvm/src/java17/resources/META-INF/services/com.example.Interface
@@ -1,0 +1,1 @@
+com.example.Seventeen

--- a/unified-prototype/unified-plugin/plugin-jvm/src/main/java/org/gradle/api/experimental/jvm/AbstractJvmLibrary.java
+++ b/unified-prototype/unified-plugin/plugin-jvm/src/main/java/org/gradle/api/experimental/jvm/AbstractJvmLibrary.java
@@ -1,0 +1,32 @@
+package org.gradle.api.experimental.jvm;
+
+import org.gradle.api.internal.CollectionCallbackActionDecorator;
+import org.gradle.internal.instantiation.InstantiatorFactory;
+import org.gradle.internal.reflect.Instantiator;
+import org.gradle.internal.service.ServiceRegistry;
+
+import javax.inject.Inject;
+
+/**
+ * The public DSL interface for a declarative JVM library.
+ */
+public abstract class AbstractJvmLibrary implements JvmLibrary {
+
+    private final JvmTargetContainer targets;
+
+    @Inject
+    public AbstractJvmLibrary(
+        Instantiator instantiator,
+        InstantiatorFactory instantiatorFactory,
+        ServiceRegistry services,
+        CollectionCallbackActionDecorator decorator
+    ) {
+        Instantiator elementInstantiator = instantiatorFactory.decorateLenient(services);
+        targets = instantiator.newInstance(JvmTargetContainer.class, instantiator, elementInstantiator, decorator);
+    }
+
+    @Override
+    public JvmTargetContainer getTargets() {
+        return targets;
+    }
+}

--- a/unified-prototype/unified-plugin/plugin-jvm/src/main/java/org/gradle/api/experimental/jvm/JavaTarget.java
+++ b/unified-prototype/unified-plugin/plugin-jvm/src/main/java/org/gradle/api/experimental/jvm/JavaTarget.java
@@ -1,0 +1,22 @@
+package org.gradle.api.experimental.jvm;
+
+import org.gradle.api.Named;
+
+public abstract class JavaTarget implements JvmTarget, Named {
+
+    private final int javaVersion;
+
+    public JavaTarget(int javaVersion) {
+        this.javaVersion = javaVersion;
+    }
+
+    @Override
+    public String getName() {
+        return "java" + javaVersion;
+    }
+
+    public int getJavaVersion() {
+        return javaVersion;
+    }
+
+}

--- a/unified-prototype/unified-plugin/plugin-jvm/src/main/java/org/gradle/api/experimental/jvm/JvmTarget.java
+++ b/unified-prototype/unified-plugin/plugin-jvm/src/main/java/org/gradle/api/experimental/jvm/JvmTarget.java
@@ -1,25 +1,17 @@
 package org.gradle.api.experimental.jvm;
 
 import org.gradle.api.Action;
+import org.gradle.api.Named;
 import org.gradle.api.experimental.common.LibraryDependencies;
 import org.gradle.api.tasks.Nested;
 
-/**
- * The public DSL interface for a declarative JVM library.
- */
-public interface JvmLibrary {
+public interface JvmTarget extends Named {
 
     @Nested
     LibraryDependencies getDependencies();
 
     default void dependencies(Action<? super LibraryDependencies> action) {
         action.execute(getDependencies());
-    }
-
-    JvmTargetContainer getTargets();
-
-    default void targets(Action<? super JvmTargetContainer> action) {
-        action.execute(getTargets());
     }
 
 }

--- a/unified-prototype/unified-plugin/plugin-jvm/src/main/java/org/gradle/api/experimental/jvm/JvmTargetContainer.java
+++ b/unified-prototype/unified-plugin/plugin-jvm/src/main/java/org/gradle/api/experimental/jvm/JvmTargetContainer.java
@@ -1,0 +1,27 @@
+package org.gradle.api.experimental.jvm;
+
+import org.gradle.api.Action;
+import org.gradle.api.internal.CollectionCallbackActionDecorator;
+import org.gradle.api.internal.DefaultNamedDomainObjectSet;
+import org.gradle.internal.reflect.Instantiator;
+
+public class JvmTargetContainer extends DefaultNamedDomainObjectSet<JvmTarget> {
+
+    private final Instantiator elementInstantiator;
+
+    public JvmTargetContainer(Instantiator instantiator, Instantiator elementInstantiator, CollectionCallbackActionDecorator callbackDecorator) {
+        super(JvmTarget.class, instantiator, callbackDecorator);
+        this.elementInstantiator = elementInstantiator;
+    }
+
+    public void java(int version) {
+        java(version, it -> {});
+    }
+
+    public void java(int version, Action<? super JvmTarget> action) {
+        JavaTarget element = elementInstantiator.newInstance(JavaTarget.class, version);
+        add(element);
+        action.execute(element);
+    }
+
+}

--- a/unified-prototype/unified-plugin/plugin-jvm/src/main/java/org/gradle/api/experimental/jvm/StandaloneJvmLibraryPlugin.java
+++ b/unified-prototype/unified-plugin/plugin-jvm/src/main/java/org/gradle/api/experimental/jvm/StandaloneJvmLibraryPlugin.java
@@ -2,6 +2,12 @@ package org.gradle.api.experimental.jvm;
 
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
+import org.gradle.api.experimental.common.LibraryDependencies;
+import org.gradle.api.plugins.JavaLibraryPlugin;
+import org.gradle.api.plugins.JavaPluginExtension;
+import org.gradle.api.plugins.internal.JavaPluginHelper;
+import org.gradle.api.tasks.SourceSet;
+import org.gradle.api.tasks.compile.JavaCompile;
 
 /**
  * Creates a declarative {@link JvmLibrary} DSL model, applies the official Jvm plugin,
@@ -10,9 +16,57 @@ import org.gradle.api.Project;
 public class StandaloneJvmLibraryPlugin implements Plugin<Project> {
     @Override
     public void apply(Project project) {
-        project.getExtensions().create("jvmLibrary", JvmLibrary.class);
-        System.out.println("Applied JVM!");
+        AbstractJvmLibrary dslModel = project.getExtensions().create("jvmLibrary", AbstractJvmLibrary.class);
 
-        // TODO: Actually do something here
+        project.getPlugins().apply(JavaLibraryPlugin.class);
+
+        linkDslModelToPluginLazy(project, dslModel);
+    }
+
+    private void linkDslModelToPluginLazy(Project project, AbstractJvmLibrary dslModel) {
+        JavaPluginExtension java = project.getExtensions().getByType(JavaPluginExtension.class);
+
+        SourceSet commonSources = JavaPluginHelper.getJavaComponent(project).getMainFeature().getSourceSet();
+        commonSources.getJava().srcDirs(project.getLayout().getProjectDirectory().dir("src").dir("common").dir("java"));
+        linkSourceSetToDependencies(project, commonSources, dslModel.getDependencies());
+
+        dslModel.getTargets().withType(JavaTarget.class).all(target -> {
+            SourceSet sourceSet = java.getSourceSets().create("java" + target.getJavaVersion());
+            java.registerFeature("java" + target.getJavaVersion(), feature -> {
+                feature.usingSourceSet(sourceSet);
+            });
+
+            // Link properties
+            project.getTasks().named(sourceSet.getCompileJavaTaskName(), JavaCompile.class, task -> {
+                task.getOptions().getRelease().set(target.getJavaVersion());
+            });
+
+            // Link dependencies to DSL
+            linkSourceSetToDependencies(project, sourceSet, target.getDependencies());
+
+            // Extend common sources
+            sourceSet.getJava().srcDirs(commonSources.getAllJava());
+
+            // Extend common dependencies
+            project.getConfigurations().getByName(sourceSet.getImplementationConfigurationName())
+                .extendsFrom(project.getConfigurations().getByName(commonSources.getImplementationConfigurationName()));
+            project.getConfigurations().getByName(sourceSet.getCompileOnlyConfigurationName())
+                .extendsFrom(project.getConfigurations().getByName(commonSources.getCompileOnlyConfigurationName()));
+            project.getConfigurations().getByName(sourceSet.getRuntimeOnlyConfigurationName())
+                .extendsFrom(project.getConfigurations().getByName(commonSources.getRuntimeOnlyConfigurationName()));
+            project.getConfigurations().getByName(sourceSet.getApiConfigurationName())
+                .extendsFrom(project.getConfigurations().getByName(commonSources.getApiConfigurationName()));
+        });
+    }
+
+    private void linkSourceSetToDependencies(Project project, SourceSet sourceSet, LibraryDependencies dependencies) {
+        project.getConfigurations().getByName(sourceSet.getImplementationConfigurationName())
+            .getDependencies().addAllLater(dependencies.getImplementation().getDependencies());
+        project.getConfigurations().getByName(sourceSet.getCompileOnlyConfigurationName())
+            .getDependencies().addAllLater(dependencies.getCompileOnly().getDependencies());
+        project.getConfigurations().getByName(sourceSet.getRuntimeOnlyConfigurationName())
+            .getDependencies().addAllLater(dependencies.getRuntimeOnly().getDependencies());
+        project.getConfigurations().getByName(sourceSet.getApiConfigurationName())
+            .getDependencies().addAllLater(dependencies.getApi().getDependencies());
     }
 }


### PR DESCRIPTION
This is a hack in that we create new features and then wire them into the main feature as targets. It works locally but the consumable configurations all have different capabilities even though they shouldn't.

Also this doesn't import into the IDE properly (red source files even though it compiles fine), since the IDE doesn't understand when a source file is part of more than one compilation. 