### PR TITLE
Replace the targets container with a static targets DSL block in the unified Android prototype

### DIFF
--- a/unified-prototype/testbed-android-groovy/build.gradle
+++ b/unified-prototype/testbed-android-groovy/build.gradle
@@ -12,7 +12,7 @@ androidLibrary {
     }
 
     targets {
-        create("debug") {
+        debug {
             dependencies {
                 implementation("org.apache.commons:commons-lang3:3.14.0")
             }

--- a/unified-prototype/testbed-android/build.gradle.kts
+++ b/unified-prototype/testbed-android/build.gradle.kts
@@ -12,7 +12,7 @@ androidLibrary {
     }
 
     targets {
-        create("debug") {
+        debug {
             dependencies {
                 implementation("org.apache.commons:commons-lang3:3.14.0")
             }

--- a/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/AndroidLibrary.java
+++ b/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/AndroidLibrary.java
@@ -12,47 +12,56 @@ import org.gradle.api.tasks.Nested;
 /**
  * The public DSL interface for a declarative Android library.
  */
-public interface AndroidLibrary {
+public abstract class AndroidLibrary {
+    private final AndroidTargets targets;
+
+    public AndroidLibrary(AndroidTargets targets) {
+        this.targets = targets;
+    }
 
     /**
      * @see CommonExtension#getNamespace()
      */
     @Input
-    Property<String> getNamespace();
+    public abstract Property<String> getNamespace();
 
     /**
      * @see CommonExtension#getCompileSdk()
      */
     @Input
-    Property<Integer> getCompileSdk();
+    public abstract Property<Integer> getCompileSdk();
 
     /**
      * @see BaseFlavor#getMinSdk()
      */
     @Input
-    Property<Integer> getMinSdk();
+    public abstract Property<Integer> getMinSdk();
 
     /**
      * JDK version to use for compilation.
      */
     @Input
-    Property<Integer> getJdkVersion();
+    public abstract Property<Integer> getJdkVersion();
 
     /**
      * Common dependencies for all targets.
      */
     @Nested
-    LibraryDependencies getDependencies();
+    public abstract LibraryDependencies getDependencies();
 
-    default void dependencies(Action<? super LibraryDependencies> action) {
+    public void dependencies(Action<? super LibraryDependencies> action) {
         action.execute(getDependencies());
     }
 
+    /**
+     * Static targets extension block.
+     */
     @Nested
-    NamedDomainObjectContainer<AndroidTarget> getTargets();
-
-    default void targets(Action<? super NamedDomainObjectContainer<AndroidTarget>> action) {
-        action.execute(getTargets());
+    public AndroidTargets getTargets() {
+        return targets;
     }
 
+    public void targets(Action<? super AndroidTargets> action) {
+        action.execute(getTargets());
+    }
 }

--- a/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/AndroidTarget.java
+++ b/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/AndroidTarget.java
@@ -3,27 +3,41 @@ package org.gradle.api.experimental.android;
 import com.android.build.api.dsl.BaseFlavor;
 import org.gradle.api.Action;
 import org.gradle.api.Named;
+import org.gradle.api.NonNullApi;
 import org.gradle.api.experimental.common.LibraryDependencies;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Nested;
 
-public interface AndroidTarget extends Named {
+import javax.inject.Inject;
+
+@NonNullApi
+public abstract class AndroidTarget implements Named {
+    private final String name;
+
+    @Inject
+    public AndroidTarget(String name) {
+        this.name = name;
+    }
 
     /**
      * @see BaseFlavor#getMinSdk()
      */
     @Input
-    Property<Integer> getMinSdk();
+    public abstract Property<Integer> getMinSdk();
 
     /**
      * Dependencies for this target.
      */
     @Nested
-    LibraryDependencies getDependencies();
+    public abstract LibraryDependencies getDependencies();
 
-    default void dependencies(Action<? super LibraryDependencies> action) {
+    public void dependencies(Action<? super LibraryDependencies> action) {
         action.execute(getDependencies());
     }
 
+    @Override
+    public String getName() {
+        return name;
+    }
 }

--- a/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/AndroidTargets.java
+++ b/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/AndroidTargets.java
@@ -1,0 +1,32 @@
+package org.gradle.api.experimental.android;
+
+import org.gradle.api.Action;
+import org.gradle.api.tasks.Nested;
+
+public abstract class AndroidTargets {
+    private final AndroidTarget debug;
+    private final AndroidTarget release;
+
+    public AndroidTargets(AndroidTarget debug, AndroidTarget release) {
+        this.debug = debug;
+        this.release = release;
+    }
+
+    @Nested
+    public AndroidTarget getDebug() {
+        return debug;
+    }
+
+    public void debug(Action<? super AndroidTarget> action) {
+        action.execute(getDebug());
+    }
+
+    @Nested
+    public AndroidTarget getRelease() {
+        return release;
+    }
+
+    public void release(Action<? super AndroidTarget> action) {
+        action.execute(getRelease());
+    }
+}

--- a/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/StandaloneAndroidLibraryPlugin.java
+++ b/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/StandaloneAndroidLibraryPlugin.java
@@ -6,17 +6,20 @@ import org.gradle.api.*;
 import org.gradle.api.provider.Property;
 import org.jetbrains.kotlin.gradle.dsl.KotlinAndroidProjectExtension;
 
+import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
+import java.util.Set;
 
 /**
  * Creates a declarative {@link AndroidLibrary} DSL model, applies the official Android plugin,
  * and links the declarative model to the official plugin.
  */
-public class StandaloneAndroidLibraryPlugin implements Plugin<Project> {
+public abstract class StandaloneAndroidLibraryPlugin implements Plugin<Project> {
     @Override
     public void apply(Project project) {
-        AndroidLibrary dslModel = project.getExtensions().create("androidLibrary", AndroidLibrary.class);
+        AndroidLibrary dslModel = createDslModel(project);
 
         // Register an afterEvaluate listener before we apply the Android plugin to ensure we can
         // run actions before Android does.
@@ -27,6 +30,13 @@ public class StandaloneAndroidLibraryPlugin implements Plugin<Project> {
         project.getPlugins().apply("org.jetbrains.kotlin.android");
 
         linkDslModelToPluginLazy(project, dslModel);
+    }
+    private AndroidLibrary createDslModel(Project project) {
+        AndroidTarget dslDebug = project.getObjects().newInstance(AndroidTarget.class, "debug");
+        AndroidTarget dslRelease = project.getObjects().newInstance(AndroidTarget.class, "release");
+        AndroidTargets dslTargets = project.getExtensions().create("targets", AndroidTargets.class, dslDebug, dslRelease);
+        AndroidLibrary dslModel = project.getExtensions().create("androidLibrary", AndroidLibrary.class, dslTargets);
+        return dslModel;
     }
 
     /**
@@ -68,7 +78,7 @@ public class StandaloneAndroidLibraryPlugin implements Plugin<Project> {
 
         // Link target-specific properties
         androidComponents.beforeVariants(androidComponents.selector().all(), variant -> {
-            AndroidTarget target = dslModel.getTargets().findByName(variant.getName());
+            AndroidTarget target = getTarget(dslModel, variant.getName());
             if (target == null) {
                 // The user did not add any target-specific configuration.
                 return;
@@ -83,8 +93,7 @@ public class StandaloneAndroidLibraryPlugin implements Plugin<Project> {
             String name = variant.getName();
             variantNames.add(name);
 
-
-            AndroidTarget target = dslModel.getTargets().findByName(name);
+            AndroidTarget target = getTarget(dslModel, variant.getName());
             if (target == null) {
                 // The user did not add any target-specific configuration.
                 return;
@@ -101,7 +110,7 @@ public class StandaloneAndroidLibraryPlugin implements Plugin<Project> {
         });
 
         // This will run after all onVariants calls.
-        project.afterEvaluate(p -> dslModel.getTargets().all(target -> {
+        project.afterEvaluate(p -> getTargets(dslModel).forEach(target -> {
             if (!variantNames.contains(target.getName())) {
                 throw new InvalidUserDataException(String.format(
                     "Configured target '%s' but an Android variant with the same name does not exist.",
@@ -117,4 +126,15 @@ public class StandaloneAndroidLibraryPlugin implements Plugin<Project> {
         }
     }
 
+    private Set<AndroidTarget> getTargets(AndroidLibrary dslModel) {
+        return Set.of(dslModel.getTargets().getDebug(), dslModel.getTargets().getRelease());
+    }
+
+    @Nullable
+    private AndroidTarget getTarget(AndroidLibrary dslModel, String name) {
+        return getTargets(dslModel).stream()
+                .filter(t -> Objects.equals(t.getName(), name))
+                .findFirst()
+                .orElse(null);
+    }
 }

--- a/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/StandaloneAndroidLibraryPlugin.java
+++ b/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/StandaloneAndroidLibraryPlugin.java
@@ -108,16 +108,6 @@ public abstract class StandaloneAndroidLibraryPlugin implements Plugin<Project> 
             project.getConfigurations().getByName(name + "RuntimeOnly").getDependencies()
                 .addAllLater(target.getDependencies().getRuntimeOnly().getDependencies());
         });
-
-        // This will run after all onVariants calls.
-        project.afterEvaluate(p -> getTargets(dslModel).forEach(target -> {
-            if (!variantNames.contains(target.getName())) {
-                throw new InvalidUserDataException(String.format(
-                    "Configured target '%s' but an Android variant with the same name does not exist.",
-                    target.getName()
-                ));
-            }
-        }));
     }
 
     private static <T> void ifPresent(Property<T> property, Action<T> action) {


### PR DESCRIPTION
This requires turning some interfaces into abstract classes to keep the Named implementation of AndroidTarget working.  It adds a new static AndroidTargets type that defines a Debug and Release target.