### PR TITLE
Use latest nightly

### DIFF
--- a/unified-prototype/gradle/wrapper/gradle-wrapper.properties
+++ b/unified-prototype/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions-snapshots/gradle-8.7-branch-tt_restrict_dependency_collector-20240213225633+0000-bin.zip
+distributionUrl=https\://services.gradle.org/distributions-snapshots/gradle-8.8-20240220001317+0000-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/unified-prototype/testbed-android/build.gradle.something
+++ b/unified-prototype/testbed-android/build.gradle.something
@@ -5,7 +5,7 @@ plugins {
 androidLibrary {
     jdkVersion = 17
     compileSdk = 34
-    namespace = "org.gradle.experimental.android.library.kotlin"
+    namespace = "org.gradle.experimental.android.library"
 
     dependencies {
         api("com.google.guava:guava:32.1.3-jre")

--- a/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/AndroidLibrary.java
+++ b/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/AndroidLibrary.java
@@ -2,12 +2,12 @@ package org.gradle.api.experimental.android;
 
 import com.android.build.api.dsl.BaseFlavor;
 import com.android.build.api.dsl.CommonExtension;
-import com.h0tk3y.kotlin.staticObjectNotation.Configuring;
-import com.h0tk3y.kotlin.staticObjectNotation.Restricted;
 import org.gradle.api.Action;
 import org.gradle.api.experimental.common.LibraryDependencies;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Property;
+import org.gradle.declarative.dsl.model.annotations.Configuring;
+import org.gradle.declarative.dsl.model.annotations.Restricted;
 
 import javax.inject.Inject;
 

--- a/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/AndroidTarget.java
+++ b/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/AndroidTarget.java
@@ -1,14 +1,14 @@
 package org.gradle.api.experimental.android;
 
 import com.android.build.api.dsl.BaseFlavor;
-import com.h0tk3y.kotlin.staticObjectNotation.Configuring;
-import com.h0tk3y.kotlin.staticObjectNotation.Restricted;
 import org.gradle.api.Action;
 import org.gradle.api.Named;
 import org.gradle.api.NonNullApi;
 import org.gradle.api.experimental.common.LibraryDependencies;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Property;
+import org.gradle.declarative.dsl.model.annotations.Configuring;
+import org.gradle.declarative.dsl.model.annotations.Restricted;
 
 import javax.inject.Inject;
 

--- a/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/AndroidTargets.java
+++ b/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/AndroidTargets.java
@@ -1,8 +1,8 @@
 package org.gradle.api.experimental.android;
 
-import com.h0tk3y.kotlin.staticObjectNotation.Configuring;
-import com.h0tk3y.kotlin.staticObjectNotation.Restricted;
 import org.gradle.api.Action;
+import org.gradle.declarative.dsl.model.annotations.Configuring;
+import org.gradle.declarative.dsl.model.annotations.Restricted;
 
 @Restricted
 public abstract class AndroidTargets {

--- a/unified-prototype/unified-plugin/plugin-common/src/main/java/org/gradle/api/experimental/common/LibraryDependencies.java
+++ b/unified-prototype/unified-plugin/plugin-common/src/main/java/org/gradle/api/experimental/common/LibraryDependencies.java
@@ -1,11 +1,11 @@
 package org.gradle.api.experimental.common;
 
-import com.h0tk3y.kotlin.staticObjectNotation.Adding;
-import com.h0tk3y.kotlin.staticObjectNotation.Restricted;
 import org.gradle.api.artifacts.dsl.DependencyCollector;
 import org.gradle.api.artifacts.dsl.GradleDependencies;
 import org.gradle.api.plugins.jvm.PlatformDependencyModifiers;
 import org.gradle.api.plugins.jvm.TestFixturesDependencyModifiers;
+import org.gradle.declarative.dsl.model.annotations.Adding;
+import org.gradle.declarative.dsl.model.annotations.Restricted;
 
 /**
  * The declarative dependencies DSL block for a library.


### PR DESCRIPTION
The declarative DSL changes have been merged into Gradle proper, so we can depend on the nightly

* Update package names
* Update android testbed namespace since there not a kotlin and groovy version of the testbed anymore